### PR TITLE
Fix commit messages with spaces cannot be made

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Create branch with name `branchName`
 await git.createBranch('new-branch');
 ```
 
+### .deleteBranch(branchName: string)
+
+Delete branch with name `branchName`
+
+```js
+await git.deleteBranch('existing-branch');
+```
+
 ### .getDiffByRevisionFileList(revision: string)
 
 Getting a list of files that have changed relative revision

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "git-interface",
-	"version": "2.0.7",
+	"version": "2.1.0",
 	"description": "some interfaces for work with git repository",
 	"main": "dist/index",
 	"typings": "dist/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ export class Git extends EventEmitter{
 
 	protected async gitExec(cmd: string): Promise<string> {
 		return new Promise<string>((resolve, reject) => {
-			const child = spawn('git', cmd.split(' '), { cwd: this.dir });
+			const splitRegex = /'[^']+'|[^\s]+/g;
+			const commandArgs = cmd.match(splitRegex).map(e => e.replace(/'(.+)'/, "'$1'"));
+			const child = spawn('git', commandArgs, { cwd: this.dir });
 			let out = '';
 
 			child.stdout.on('data', (data) => { out += data.toString(); this.emit('out', data.toString()); });
@@ -32,7 +34,7 @@ export class Git extends EventEmitter{
 				if (code === 0) {
 					resolve(out);
 				} else {
-					reject();
+					reject(new Error(out));
 				}
 			});
 		});
@@ -84,8 +86,10 @@ export class Git extends EventEmitter{
 		return this.gitExec(command);
 	}
 
-	public commit(message: string) {
-		return this.gitExec(`commit -am ${message}`);
+	public commit(message: string, all: boolean = false) {
+		const escapedMessage = message.replace(/'/g, "\\'");
+		const allOption = all ? 'a' : ''
+		return this.gitExec(`commit -${allOption}m '${escapedMessage}'`);
 	}
 
 	public pull() {
@@ -162,6 +166,10 @@ export class Git extends EventEmitter{
 
 	public createBranch(branchName: string) {
 		return this.gitExec(`checkout -b ${branchName}`);
+	}
+
+	public deleteBranch(branchName: string) {
+		return this.gitExec(`branch -D ${branchName}`);
 	}
 
 	public getDiffByRevisionFileList(revision: string): Promise<string[]> {


### PR DESCRIPTION
## Add error output on promise rejection
When my commit started to fail I was unable to debug the issue because no error output was being sent back with the promise rejection. Now when commands fail, there will at least be some information as to why the command failed.

## Add quote marks around commit message
Since I had a space in my commit message, I needed to add quotes around it. End users wouldn't expect to have to pass a string with quotes. 

## Fix commit messages with spaces cannot be made
Because command was being split by space, even after I added quote marks, I had to change how the command was split so that quoted strings wouldn't get split apart.

## Add option to commit to auto stage un-staged files. Default is now false.
I do not think the default behavior should be to auto-stage files when committing. I think this is more of a developer preference which is why I still allowed developer to specify it as an option. This can potentially break existing usages of this method which is why I bumped the minor version rather than patch version.
 
## Add delete branch method
While automating creation of a clean commit, it seemed wise to delete any branch that might already exist. I can separate this onto a different PR if you like.